### PR TITLE
Extend types with Codable support.

### DIFF
--- a/Sources/DockerClientSwift/Models/Container.swift
+++ b/Sources/DockerClientSwift/Models/Container.swift
@@ -10,3 +10,5 @@ public struct Container {
     public var state: String
     public var command: String
 }
+
+extension Container: Codable {}

--- a/Sources/DockerClientSwift/Models/DockerVersion.swift
+++ b/Sources/DockerClientSwift/Models/DockerVersion.swift
@@ -5,3 +5,5 @@ public struct DockerVersion {
     public let minAPIVersion: String
     public let os: String
 }
+
+extension DockerVersion: Codable {}

--- a/Sources/DockerClientSwift/Models/Identifier.swift
+++ b/Sources/DockerClientSwift/Models/Identifier.swift
@@ -2,7 +2,7 @@ public struct Identifier<T> {
     public init(_ value: String) {
         self.value = value
     }
-    
+
     public typealias StringLiteralType = String
 
     public var value: String
@@ -15,3 +15,5 @@ extension Identifier: ExpressibleByStringLiteral {
 }
 
 extension Identifier: Equatable { }
+
+extension Identifier: Codable {}

--- a/Sources/DockerClientSwift/Models/Image.swift
+++ b/Sources/DockerClientSwift/Models/Image.swift
@@ -6,38 +6,38 @@ public struct Image {
 
     /// Local ID of the image. This can vary from instant to instant.
     public var id: Identifier<Image>
-    
+
     /// The unique hash of the image layer that is exposed. Format: {hash algorithm}:{hash value}.
     public var digest: Digest?
-    
+
     /// Names and tags of the image that it has in the repository.
     public var repositoryTags: [RepositoryTag]
-    
+
     /// Date when the image was created.
     public var createdAt: Date?
-    
+
     public struct RepositoryTag {
         public var repository: String
         public var tag: String?
     }
-    
+
     internal init(id: Identifier<Image>, digest: Digest? = nil, repoTags: [String]?=nil, createdAt: Date?=nil) {
         let repositoryTags = repoTags.map({ repoTags in
             repoTags.compactMap { repoTag in
                 return RepositoryTag(repoTag)
             }
         }) ?? []
-        
+
         self.init(id: id, digest: digest, repositoryTags: repositoryTags, createdAt: createdAt)
     }
-    
+
     internal init(id: Identifier<Image>, digest: Digest? = nil, repositoryTags: [RepositoryTag]?=nil, createdAt: Date?=nil) {
         self.id = id
         self.digest = digest
         self.createdAt = createdAt
         self.repositoryTags = repositoryTags ?? []
     }
-    
+
     internal init(id: Identifier<Image>) {
         self.id = id
         self.repositoryTags = []
@@ -58,3 +58,6 @@ extension Image.RepositoryTag {
         }
     }
 }
+
+extension Image: Codable {}
+extension Image.RepositoryTag: Codable {}

--- a/Sources/DockerClientSwift/Models/Service.swift
+++ b/Sources/DockerClientSwift/Models/Service.swift
@@ -10,3 +10,5 @@ public struct Service {
     public var version: Int
     public var image: Image
 }
+
+extension Service: Codable {}

--- a/Sources/DockerClientSwift/Models/Utilitities.swift
+++ b/Sources/DockerClientSwift/Models/Utilitities.swift
@@ -11,7 +11,7 @@ public struct MessageResponse: Codable {
 /// Representation of an image digest.
 public struct Digest {
     public var rawValue: String
-    
+
     init(_ rawValue: String) {
         self.rawValue = rawValue
     }
@@ -22,6 +22,8 @@ extension Digest: ExpressibleByStringLiteral {
         self.rawValue = value
     }
 }
+
+extension Digest: Codable {}
 
 public enum DockerError: Error {
     case message(String)


### PR DESCRIPTION
Extend public models with `Codable`.
This could make the use of API server easier, allowing to exchange Docker types directly.