### PR TITLE
Create container with port forwarding

### DIFF
--- a/Sources/DockerClientSwift/APIs/DockerClient+Container.swift
+++ b/Sources/DockerClientSwift/APIs/DockerClient+Container.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 import NIO
 
 extension DockerClient {
@@ -36,10 +37,25 @@ extension DockerClient {
         /// - Parameters:
         ///   - image: Instance of an `Image`.
         ///   - commands: Override the default commands from the image. Default `nil`.
+        ///   - portBindings: Port bindings (forwardings). See ``PortBinding`` for details. Default `[]`.
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns an `EventLoopFuture` of a `Container`.
-        public func createContainer(image: Image, commands: [String]?=nil) throws -> EventLoopFuture<Container> {
-            return try client.run(CreateContainerEndpoint(imageName: image.id.value, commands: commands))
+        public func createContainer(image: Image, commands: [String]?=nil, portBindings: [PortBinding]=[]) throws -> EventLoopFuture<Container> {
+            let hostConfig: CreateContainerEndpoint.CreateContainerBody.HostConfig?
+            if portBindings.isEmpty {
+                hostConfig = nil
+            } else {
+                var portBindingsByContainerPort: [String: [CreateContainerEndpoint.CreateContainerBody.HostConfig.PortBinding]] = [:]
+                for portBinding in portBindings {
+                    let containerPort: String = "\(portBinding.containerPort)/\(portBinding.networkProtocol)"
+                    var hostAddresses = portBindingsByContainerPort[containerPort, default: []]
+                    hostAddresses.append(
+                        CreateContainerEndpoint.CreateContainerBody.HostConfig.PortBinding(HostIp: "\(portBinding.hostIP)", HostPort: "\(portBinding.hostPort)"))
+                    portBindingsByContainerPort[containerPort] = hostAddresses
+                }
+                hostConfig = CreateContainerEndpoint.CreateContainerBody.HostConfig(PortBindings: portBindingsByContainerPort)
+            }
+            return try client.run(CreateContainerEndpoint(imageName: image.id.value, commands: commands, hostConfig: hostConfig))
                 .flatMap({ response in
                     try self.get(containerByNameOrId: response.Id)
                 })
@@ -48,10 +64,36 @@ extension DockerClient {
         /// Starts a container. Before starting it needs to be created.
         /// - Parameter container: Instance of a created `Container`.
         /// - Throws: Errors that can occur when executing the request.
-        /// - Returns: Returns an `EventLoopFuture` when the container is started.
-        public func start(container: Container) throws -> EventLoopFuture<Void> {
+        /// - Returns: Returns an `EventLoopFuture` of active actual `PortBinding`s when the container is started.
+        public func start(container: Container) throws -> EventLoopFuture<[PortBinding]> {
             return try client.run(StartContainerEndpoint(containerId: container.id.value))
-                .map({ _ in Void() })
+                .flatMap { _ in
+                    try client.run(InspectContainerEndpoint(nameOrId: container.id.value))
+                        .flatMapThrowing { response in
+                            try response.NetworkSettings.Ports.flatMap { (containerPortSpec, bindings) in
+                                let containerPortParts = containerPortSpec.split(separator: "/", maxSplits: 2)
+                                guard
+                                    let containerPort: UInt16 = UInt16(containerPortParts[0]),
+                                    let networkProtocol: NetworkProtocol = NetworkProtocol(rawValue: String(containerPortParts[1]))
+                                else { throw DockerError.message(#"unable to parse port/protocol from NetworkSettings.Ports key - "\#(containerPortSpec)""#) }
+                                
+                                return try (bindings ?? []).compactMap { binding in
+                                    guard
+                                        let hostIP: IPAddress = IPv4Address(binding.HostIp) ?? IPv6Address(binding.HostIp)
+                                    else {
+                                        throw DockerError.message(#"unable to parse IPAddress from NetworkSettings.Ports[].HostIp - "\#(binding.HostIp)""#)
+                                    }
+                                    guard
+                                        let hostPort = UInt16(binding.HostPort)
+                                    else {
+                                        throw DockerError.message(#"unable to parse port number from NetworkSettings.Ports[].HostPort - "\#(binding.HostPort)""#)
+                                    }
+
+                                    return PortBinding(hostIP: hostIP, hostPort: hostPort, containerPort: containerPort, networkProtocol: networkProtocol)
+                                }
+                            }
+                        }
+                }
         }
         
         /// Stops a container. Before stopping it needs to be created and started..
@@ -134,7 +176,7 @@ extension Container {
     /// - Parameter client: A `DockerClient` instance that is used to perform the request.
     /// - Throws: Errors that can occur when executing the request.
     /// - Returns: Returns an `EventLoopFuture` when the container is started.
-    public func start(on client: DockerClient) throws -> EventLoopFuture<Void> {
+    public func start(on client: DockerClient) throws -> EventLoopFuture<[PortBinding]> {
         try client.containers.start(container: self)
     }
     

--- a/Sources/DockerClientSwift/Endpoints/Containers/CreateContainerEndpoint.swift
+++ b/Sources/DockerClientSwift/Endpoints/Containers/CreateContainerEndpoint.swift
@@ -10,10 +10,10 @@ struct CreateContainerEndpoint: Endpoint {
     private let imageName: String
     private let commands: [String]?
     
-    init(imageName: String, commands: [String]?=nil) {
+    init(imageName: String, commands: [String]?=nil, hostConfig: CreateContainerBody.HostConfig?=nil) {
         self.imageName = imageName
         self.commands = commands
-        self.body = .init(Image: imageName, Cmd: commands)
+        self.body = .init(Image: imageName, Cmd: commands, HostConfig: hostConfig)
     }
     
     var path: String {
@@ -23,6 +23,16 @@ struct CreateContainerEndpoint: Endpoint {
     struct CreateContainerBody: Codable {
         let Image: String
         let Cmd: [String]?
+        let HostConfig: HostConfig?
+        
+        struct HostConfig: Codable {
+            let PortBindings: [String: [PortBinding]?]
+            
+            struct PortBinding: Codable {
+                let HostIp: String?
+                let HostPort: String?
+            }
+        }
     }
     
     struct CreateContainerResponse: Codable {

--- a/Sources/DockerClientSwift/Endpoints/Containers/CreateContainerEndpoint.swift
+++ b/Sources/DockerClientSwift/Endpoints/Containers/CreateContainerEndpoint.swift
@@ -10,10 +10,10 @@ struct CreateContainerEndpoint: Endpoint {
     private let imageName: String
     private let commands: [String]?
     
-    init(imageName: String, commands: [String]?=nil, hostConfig: CreateContainerBody.HostConfig?=nil) {
+    init(imageName: String, commands: [String]?=nil, exposedPorts: [String: CreateContainerBody.Empty]?=nil, hostConfig: CreateContainerBody.HostConfig?=nil) {
         self.imageName = imageName
         self.commands = commands
-        self.body = .init(Image: imageName, Cmd: commands, HostConfig: hostConfig)
+        self.body = .init(Image: imageName, Cmd: commands, ExposedPorts: exposedPorts, HostConfig: hostConfig)
     }
     
     var path: String {
@@ -23,7 +23,10 @@ struct CreateContainerEndpoint: Endpoint {
     struct CreateContainerBody: Codable {
         let Image: String
         let Cmd: [String]?
+        let ExposedPorts: [String: Empty]?
         let HostConfig: HostConfig?
+        
+        struct Empty: Codable {}
         
         struct HostConfig: Codable {
             let PortBindings: [String: [PortBinding]?]

--- a/Sources/DockerClientSwift/Endpoints/Containers/InspectContainerEndpoint.swift
+++ b/Sources/DockerClientSwift/Endpoints/Containers/InspectContainerEndpoint.swift
@@ -22,6 +22,7 @@ struct InspectContainerEndpoint: Endpoint {
         let Image: String
         let Created: String
         let State: StateResponse
+        let NetworkSettings: NetworkSettings
         // TODO: Add additional fields
         
         struct StateResponse: Codable {
@@ -31,6 +32,15 @@ struct InspectContainerEndpoint: Endpoint {
         
         struct ConfigResponse: Codable {
             let Cmd: [String]
+        }
+        
+        struct NetworkSettings: Codable {
+            let Ports: [String: [PortBinding]?]
+            
+            struct PortBinding: Codable {
+                let HostIp: String
+                let HostPort: String
+            }
         }
     }
 }

--- a/Sources/DockerClientSwift/Endpoints/Containers/InspectContainerEndpoint.swift
+++ b/Sources/DockerClientSwift/Endpoints/Containers/InspectContainerEndpoint.swift
@@ -31,7 +31,7 @@ struct InspectContainerEndpoint: Endpoint {
         }
         
         struct ConfigResponse: Codable {
-            let Cmd: [String]
+            let Cmd: [String]?
         }
         
         struct NetworkSettings: Codable {

--- a/Sources/DockerClientSwift/Models/Container.swift
+++ b/Sources/DockerClientSwift/Models/Container.swift
@@ -25,7 +25,7 @@ public struct PortBinding {
     ///
     /// - Parameters:
     ///   - hostIP: The host IP address to map the connection to. Default `0.0.0.0`.
-    ///   - hostPort: The port on the Docker host to map connections to 0 means map to a random available port. Default `0`.
+    ///   - hostPort: The port on the Docker host to map connections to. `0` means map to a random available port. Default `0`.
     ///   - containerPort: The port on the container to map connections from.
     ///   - networkProtocol: The protocol (`tcp`/`udp`) to bind. Default `tcp`.
     public init(hostIP: IPAddress=IPv4Address.any, hostPort: UInt16=0, containerPort: UInt16, networkProtocol: NetworkProtocol = .tcp) {

--- a/Sources/DockerClientSwift/Models/Container.swift
+++ b/Sources/DockerClientSwift/Models/Container.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 
 /// Representation of a container.
 /// Some actions can be performed on an instance.
@@ -12,3 +13,30 @@ public struct Container {
 }
 
 extension Container: Codable {}
+
+/// Representation of a port binding
+public struct PortBinding {
+    public var hostIP: IPAddress
+    public var hostPort: UInt16
+    public var containerPort: UInt16
+    public var networkProtocol: NetworkProtocol
+    
+    /// Creates a PortBinding
+    ///
+    /// - Parameters:
+    ///   - hostIP: The host IP address to map the connection to. Default `0.0.0.0`.
+    ///   - hostPort: The port on the Docker host to map connections to 0 means map to a random available port. Default `0`.
+    ///   - containerPort: The port on the container to map connections from.
+    ///   - networkProtocol: The protocol (`tcp`/`udp`) to bind. Default `tcp`.
+    public init(hostIP: IPAddress=IPv4Address.any, hostPort: UInt16=0, containerPort: UInt16, networkProtocol: NetworkProtocol = .tcp) {
+        self.hostIP = hostIP
+        self.hostPort = hostPort
+        self.containerPort = containerPort
+        self.networkProtocol = networkProtocol
+    }
+}
+
+public enum NetworkProtocol: String {
+    case tcp
+    case udp
+}

--- a/Tests/DockerClientTests/ContainerTests.swift
+++ b/Tests/DockerClientTests/ContainerTests.swift
@@ -17,7 +17,7 @@ final class ContainerTests: XCTestCase {
     func testCreateContainers() throws {
         let image = try client.images.pullImage(byName: "hello-world", tag: "latest").wait()
         let container = try client.containers.createContainer(image: image).wait()
-
+        
         XCTAssertEqual(container.command, "/hello")
     }
     
@@ -26,7 +26,7 @@ final class ContainerTests: XCTestCase {
         let _ = try client.containers.createContainer(image: image).wait()
         
         let containers = try client.containers.list(all: true).wait()
-    
+        
         XCTAssert(containers.count >= 1)
     }
     
@@ -57,7 +57,7 @@ final class ContainerTests: XCTestCase {
             
             Hello from Docker!
             This message shows that your installation appears to be working correctly.
-
+            
             To generate this message, Docker took the following steps:
              1. The Docker client contacted the Docker daemon.
              2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
@@ -67,18 +67,17 @@ final class ContainerTests: XCTestCase {
                 executable that produces the output you are currently reading.
              4. The Docker daemon streamed that output to the Docker client, which sent it
                 to your terminal.
-
+            
             To try something more ambitious, you can run an Ubuntu container with:
              $ docker run -it ubuntu bash
-
+            
             Share images, automate workflows, and more with a free Docker ID:
              https://hub.docker.com/
-
+            
             For more examples and ideas, visit:
              https://docs.docker.com/get-started/
-
+            
             """
-
         
         XCTAssertTrue(
             output.hasPrefix(expectedOutputPrefix),

--- a/Tests/DockerClientTests/ContainerTests.swift
+++ b/Tests/DockerClientTests/ContainerTests.swift
@@ -45,18 +45,24 @@ final class ContainerTests: XCTestCase {
         let container = try client.containers.createContainer(image: image).wait()
         try container.start(on: client).wait()
         let output = try container.logs(on: client).wait()
-        
-        XCTAssertEqual(
-            output,
-            """
-
+        // Depending on CPU architecture, step 2 of the log output may by:
+        // 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+        //    (amd64)
+        // or
+        // 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+        //    (arm64v8)
+        //
+        // Just check the lines before and after this line
+        let expectedOutputPrefix = """
+            
             Hello from Docker!
             This message shows that your installation appears to be working correctly.
 
             To generate this message, Docker took the following steps:
              1. The Docker client contacted the Docker daemon.
              2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-                (amd64)
+            """
+        let expectedOutputSuffix = """
              3. The Docker daemon created a new container from that image which runs the
                 executable that produces the output you are currently reading.
              4. The Docker daemon streamed that output to the Docker client, which sent it
@@ -71,6 +77,23 @@ final class ContainerTests: XCTestCase {
             For more examples and ideas, visit:
              https://docs.docker.com/get-started/
 
+            """
+
+        
+        XCTAssertTrue(
+            output.hasPrefix(expectedOutputPrefix),
+            """
+            "\(output)"
+            did not start with
+            "\(expectedOutputPrefix)"
+            """
+        )
+        XCTAssertTrue(
+            output.hasSuffix(expectedOutputSuffix),
+            """
+            "\(output)"
+            did not end with
+            "\(expectedOutputSuffix)"
             """
         )
     }


### PR DESCRIPTION
This PR resolves https://github.com/alexsteinerde/docker-client-swift/issues/8 by adding the ability to create containers with port forwarding. The changes are non-breaking:

1. `DockerClient#createContainer(...)` updated to take a third `portBindings` parameter that is an array of `PortBinding`s (defaulting to empty array - no port forwarding). (See [doc comment](https://github.com/jackgene/docker-client-swift/blob/feature/port-forwarding/Sources/DockerClientSwift/Models/Container.swift#L24-L30) for details) of `PortBinding`.
2. `DockerClient#start(...)` updated to return an array of `PortBinding`s -indicating the the actual port bindings. This is mainly for use cases where the client makes a request to forward to a random available host port (`hostPort=0`), such that the client is able to get the actual bound port. If the requested `hostPort` is non-0, the return value should just be what the client provided.

Changes were made to the Docker JSON model to support this.