### PR TITLE
Fix the infinite recursion issue.

### DIFF
--- a/Sources/DockerClientSwift/APIs/DockerClient+Container.swift
+++ b/Sources/DockerClientSwift/APIs/DockerClient+Container.swift
@@ -61,7 +61,7 @@ extension DockerClient {
                 hostConfig = CreateContainerEndpoint.CreateContainerBody.HostConfig(PortBindings: portBindingsByContainerPort)
             }
             return try client.run(CreateContainerEndpoint(imageName: image.id.value, commands: commands, exposedPorts: exposedPorts, hostConfig: hostConfig))
-                .flatMap({ response in
+                ._flatMap({ response in
                     try self.get(containerByNameOrId: response.Id)
                 })
         }
@@ -72,7 +72,7 @@ extension DockerClient {
         /// - Returns: Returns an `EventLoopFuture` of active actual `PortBinding`s when the container is started.
         public func start(container: Container) throws -> EventLoopFuture<[PortBinding]> {
             return try client.run(StartContainerEndpoint(containerId: container.id.value))
-                .flatMap { _ in
+                ._flatMap { _ in
                     try client.run(InspectContainerEndpoint(nameOrId: container.id.value))
                         .flatMapThrowing { response in
                             try response.NetworkSettings.Ports.flatMap { (containerPortSpec, bindings) in

--- a/Sources/DockerClientSwift/APIs/DockerClient+Image.swift
+++ b/Sources/DockerClientSwift/APIs/DockerClient+Image.swift
@@ -36,7 +36,7 @@ extension DockerClient {
         /// - Returns: Fetches the latest image information and returns an `EventLoopFuture` with the `Image` that has been fetched.
         public func pullImage(byIdentifier identifier: String) throws -> EventLoopFuture<Image> {
             return try client.run(PullImageEndpoint(imageName: identifier))
-                .flatMap({ _ in
+                ._flatMap({ _ in
                     try self.get(imageByNameOrId: identifier)
                 })
         }

--- a/Sources/DockerClientSwift/APIs/DockerClient+Service.swift
+++ b/Sources/DockerClientSwift/APIs/DockerClient+Service.swift
@@ -31,7 +31,7 @@ extension DockerClient {
         /// - Returns: Returns an `EventLoopFuture` with the updated `Service`.
         public func update(service: Service, newImage: Image) throws -> EventLoopFuture<Service> {
             try client.run(UpdateServiceEndpoint(nameOrId: service.id.value, name: service.name, version: service.version, image: newImage.id.value))
-                .flatMap({ _ in
+                ._flatMap({ _ in
                     try self.get(serviceByNameOrId: service.id.value)
                 })
         }
@@ -56,7 +56,7 @@ extension DockerClient {
         /// - Returns: Returns an `EventLoopFuture` with the newly created `Service`.
         public func create(serviceName name: String, image: Image) throws -> EventLoopFuture<Service> {
             try client.run(CreateServiceEndpoint(name: name, image: image.id.value))
-                .flatMap({ serviceId in
+                ._flatMap({ serviceId in
                     try client.run(InspectServiceEndpoint(nameOrId: serviceId.ID))
                 })
                 .map({ service in

--- a/Sources/DockerClientSwift/Helper/EventLoopFuture+FlatMap.swift
+++ b/Sources/DockerClientSwift/Helper/EventLoopFuture+FlatMap.swift
@@ -5,7 +5,7 @@ extension EventLoopFuture {
     /// - Parameters:
     ///   - callback: Throwing closure that returns and `EventLoopFuture` of the result type.
     /// - Returns: Returns an `EventLoopFuture` with the value of the callback future.
-    @inlinable public func flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Value) throws -> EventLoopFuture<NewValue>) -> EventLoopFuture<NewValue> {
+    @inlinable func _flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Value) throws -> EventLoopFuture<NewValue>) -> EventLoopFuture<NewValue> {
         self.flatMap { value in
             do {
                 return try callback(value)
@@ -15,3 +15,4 @@ extension EventLoopFuture {
         }
     }
 }
+


### PR DESCRIPTION
When using this library with swift-nio 2.76.1, I encountered an issue where `EventLoopFuture.flatMap` led to infinite recursion. To resolve this, I renamed it to `EventLoopFuture._flatMap`.

Additionally, I updated the access level to internal, as it doesn’t appear necessary to expose it publicly.
